### PR TITLE
take outfile as optional parameter and also fixup filtering logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,13 @@ author: "David Andrew"
 inputs:
   github_token:
     description: "GitHub PAT"
+    required: true
   github_repository:
     description: "The github repository to read the workflows logs from"
+    required: true
   github_run_id:
     description: "The workflow specific run id to read the logs from"
+    required: true
   outfile:
     description: "the file to create. A null/empty value will send results to the output variable `result` instead."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: "The github repository to read the workflows logs from"
   github_run_id:
     description: "The workflow specific run id to read the logs from"
+  outfile:
+    description: "the file to create. A null/empty value will send results to the output variable `result` instead."
+    required: false
 
 outputs:
   result:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
-const fetch = require ('cross-fetch')
+const fetch = require('cross-fetch')
+const fs = require('fs')
 
 function assert(condition, message) {
     if (!condition) {
@@ -26,9 +27,13 @@ try {
 } catch (error) {
     core.setFailed(error.message)
 }
+var outfile = core.getInput('outfile') || process.env.GITHUB_DUMP_LOGS_OUTFILE;
+if (typeof outfile === 'undefined') {
+    outfile = ''
+}
 const metadata_url = `https://git.providence.org/api/v3/repos/${github_repo}/actions/runs/${github_run_id}`
 
-console.log(`\ngithub_repo: ${github_repo}\ngithub_run_id: ${github_run_id}\ngithub_token: ${github_token}`)
+console.log(`\ngithub_repo: ${github_repo}\ngithub_run_id: ${github_run_id}\ngithub_token: ${github_token}\noutfile: '${outfile}'`)
 
 try {
     console.log(`Fetching job metadata from ${metadata_url}`)
@@ -87,7 +92,8 @@ try {
                             return response.text()
                         })
                         .then(data => {
-                            core.setOutput("result", data);
+                            if (outfile) { fs.writeFileSync(outfile, data) }
+                            else { core.setOutput("result", data) }
                         })
 
                     } catch (error) {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ try {
             })
             .then(data => {
                 var jobs = {}
-                data.jobs.filter(job => job.id !== 'completed').forEach(job => {
+                data.jobs.filter(job => job.status == 'completed').forEach(job => {
+                    console.log(`adding job '${job.id}/${job.name}' with status '${job.status}' and conclusion '${job.conclusion}'`)
                     jobs[job.id] = {
                         job_id: job.id,
                         job_name: job.name,
@@ -87,23 +88,21 @@ try {
                         })
                         .then(response => {
                             if (!response.ok) {
-                                throw new Error(`Job log failed with status ${response.status}`)
+                                throw new Error(`Log request failed with status ${response.status} for job id '${job_id}'`)
                             }
                             return response.text()
                         })
                         .then(data => {
+                            console.log(`Writing data, length=${data.length}`)
                             if (outfile) { fs.writeFileSync(outfile, data) }
                             else { core.setOutput("result", data) }
                         })
-
                     } catch (error) {
-                          core.setFailed(error.message)
-                      }
+                        core.setFailed(error.message)
+                    }
                 }
             })
         })
-
-
 } catch (error) {
     core.setFailed(error.message)
 }


### PR DESCRIPTION
This PR 
- changes the action to accept an optional 'outfile' parameter.
  - this change is backward compatible - omit he parameter to retain previous behavior.
- fixes the .filter() logic, adds logging and also marks the inputs as required to eliminate warnings for action.yml.
  - the .filter() logic was both backwards (!== vs ==) and also referencing the wrong property by mistake (job.id vs job.status)

(I did not address the "UnhandledPromiseRejectionWarning". It shouldn't come up, now that .filter() is fixed, but it should still be handled at some point.)